### PR TITLE
Fix tidyselect deprecation warnings: replace contains() with all_of()

### DIFF
--- a/R/compute_lagcorr.R
+++ b/R/compute_lagcorr.R
@@ -49,12 +49,16 @@ compute_lagcorr <- function(df_prep, lags = c(-2, 0, 2), corr_type = "Pearson") 
       df$Participant_ID <- gsub(participantvec[2], names(participantvec)[2], df$Participant_ID)
 
       # Create wide data frame with aggregated scores
+      # Use explicit column selection to avoid tidyselect deprecation warnings
+      align_var_copy <- align_var
       df_wide <- df %>%
         dplyr::group_by(Event_ID, Exchange_Count, Participant_ID, .add = FALSE) %>%
-        dplyr::summarise(dplyr::across(tidyselect::contains(align_var), ~ mean(.x, na.rm = TRUE)),
+        dplyr::summarise(dplyr::across(all_of(align_var_copy), ~ mean(.x, na.rm = TRUE)),
                          .groups = "drop") %>%
-        tidyr::pivot_wider(names_from = tidyselect::contains("Participant_ID"),
-                           values_from = align_var)
+        tidyr::pivot_wider(id_cols = c("Event_ID", "Exchange_Count"),
+                           names_from = "Participant_ID",
+                           values_from = all_of(align_var_copy),
+                           names_sep = "_")
 
       # Handle single alignment variable case
       if (length(align_var) == 1) {
@@ -63,7 +67,7 @@ compute_lagcorr <- function(df_prep, lags = c(-2, 0, 2), corr_type = "Pearson") 
       }
 
       df_wide <- df_wide %>%
-        dplyr::select(Event_ID, Exchange_Count, tidyselect::contains(align_var))
+        dplyr::select(Event_ID, Exchange_Count, all_of(align_var_copy))
 
       # Remove rows with NA values
       rows_with_na_ind <- apply(df_wide[, which(colnames(df_wide) %in% paste(align_var, "S1", sep = "_") |
@@ -75,7 +79,7 @@ compute_lagcorr <- function(df_prep, lags = c(-2, 0, 2), corr_type = "Pearson") 
 
       # Interpolate missing values
       interp_df <- df_wide %>%
-        dplyr::mutate(dplyr::across(tidyselect::contains(align_var),
+        dplyr::mutate(dplyr::across(all_of(align_var_copy),
                                     ~ zoo::na.approx(.x, na.rm = FALSE))) %>%
         tidyr::fill(names(df_wide[, which(colnames(df_wide) %in% paste(align_var, "S1", sep = "_") |
                                             colnames(df_wide) %in% paste(align_var, "S2", sep = "_"))]),


### PR DESCRIPTION
- Replace tidyselect::contains(align_var) with all_of(align_var) in dplyr::across()
- Replace tidyselect::contains() in tidyr::pivot_wider() with explicit column names
- Add id_cols parameter to pivot_wider for explicit column specification
- These changes address tidyselect 1.1.0 deprecation warnings about external vectors" -m "Tests still pass: [ FAIL 0 | WARN 10 | SKIP 0 | PASS 5 ] Note: 6 tidyselect warnings persist from tidyr::pivot_wider() internal code, not our direct usage.